### PR TITLE
Better support of blech32m

### DIFF
--- a/src/blech32.ts
+++ b/src/blech32.ts
@@ -1,4 +1,5 @@
 import Long from "long";
+import { validateWitnessVersion } from "./utils";
 
 const CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 export const MAX_LEN = 1000;
@@ -18,6 +19,19 @@ const GENERATORS = [
 export type EncodingType = "blech32" | "blech32m";
 export const BLECH32: EncodingType = "blech32";
 export const BLECH32M: EncodingType = "blech32m";
+
+export function getEncodingType(witnessVersion: number): EncodingType {
+  validateWitnessVersion(witnessVersion);
+  if (witnessVersion === 0) {
+    return BLECH32;
+  } else if (witnessVersion === 1) {
+    return BLECH32M;
+  } else {
+    throw new Error(
+      `Unsuported witness version (${witnessVersion}), only 0 (blech32) or 1 (blech32m) are supported`
+    );
+  }
+}
 
 function getEncodingConst(enc: EncodingType): Long.Long {
   if (enc === BLECH32) {
@@ -151,7 +165,7 @@ export function decode(
   }
 
   if (!verifyChecksum(hrp, data, enc)) {
-    throw new Error("invalid blech32 checksum");
+    throw new Error(`invalid ${enc} checksum`);
   }
 
   return { hrp: hrp, data: Uint8Array.from(data.slice(0, data.length - 12)) };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,9 @@ export function convertBits(
 
   return regrouped;
 }
+
+export function validateWitnessVersion(version: number): void {
+  if (version < 0 || version > 16) {
+    throw new Error("invalid witness version");
+  }
+}

--- a/test/blech32Address.test.ts
+++ b/test/blech32Address.test.ts
@@ -1,24 +1,58 @@
-import { Blech32Address } from "../src";
-import {
-  invalidFixtures,
-  validFixtures
-} from "./fixtures/blech32Address.fixture";
+import { BLECH32, Blech32Address, BLECH32M } from "../src";
+import * as blech32fixture from "./fixtures/blech32Address.fixture";
+import * as blech32mfixture from "./fixtures/blech32mAddress.fixture";
 import { strictEqual, throws } from "assert";
 
-describe("Blech32 Address", () => {
+describe("Blech32 Address (witness version: 0)", () => {
+  const { validFixtures, invalidFixtures } = blech32fixture;
+
   it("should compute blech32 addresses from witness program, a blinding public key and a prefix", () => {
     for (const f of validFixtures) {
-      const addr = Blech32Address.from(f.witness, f.blindingPublicKey, f.prefix)
-        .address;
+      const addrObj = Blech32Address.from(
+        f.witness,
+        f.blindingPublicKey,
+        f.prefix,
+        0
+      );
+      strictEqual(addrObj.witnessVersion, 0);
+
+      const addr = addrObj.address;
 
       strictEqual(addr, f.address);
-      strictEqual(addr, Blech32Address.fromString(f.address).address);
+      strictEqual(addr, Blech32Address.fromString(f.address, BLECH32).address);
     }
   });
 
   it("should throw an error if we try to decode an invalid blech32 address", () => {
     for (const str of invalidFixtures) {
-      throws(() => Blech32Address.fromString(str));
+      throws(() => Blech32Address.fromString(str, BLECH32));
+    }
+  });
+});
+
+describe("Blech32m Address (witness version: 1)", () => {
+  const { validFixtures, invalidFixtures } = blech32mfixture;
+
+  it("should compute blech32m addresses from witness program, a blinding public key and a prefix", () => {
+    for (const f of validFixtures) {
+      // console.log(Blech32Address.fromString(f.address));
+      const addrObj = Blech32Address.from(
+        f.witness,
+        f.blindingPublicKey,
+        f.prefix,
+        1
+      );
+      strictEqual(addrObj.witnessVersion, 1);
+
+      const addr = addrObj.address;
+      strictEqual(addr, f.address);
+      strictEqual(addr, Blech32Address.fromString(f.address, BLECH32M).address);
+    }
+  });
+
+  it("should throw an error if we try to decode an invalid blech32 address", () => {
+    for (const str of invalidFixtures) {
+      throws(() => Blech32Address.fromString(str, BLECH32M));
     }
   });
 });

--- a/test/fixtures/blech32mAddress.fixture.ts
+++ b/test/fixtures/blech32mAddress.fixture.ts
@@ -1,0 +1,18 @@
+export const validFixtures = [
+  {
+    address:
+      "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqzacec9ttt8re",
+    witness: "d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
+    blindingPublicKey:
+      "02bb66710acfd4346bebd772eb9462279a8fa4bd93763b5a7373bf1938c84dae53",
+    prefix: "tex"
+  }
+];
+
+export const invalidFixtures = [
+  "tex1p6jx06jkxz4ladad29vwvssn82xlfu89cwm50dg8zvlzjcmcgpwdsw9ee67", // unconfidential taproot address
+  "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqzacec9ttt8reaa", // invalid CT address
+  "ert1q2z45rh444qmeand48lq0wp3jatxs2nzh492ds9s5yscv2pplxwesajz7q3", // P2WSH (unconfidential)
+  "ex1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5vqrmu3", // P2SH (unconfidential)
+  ""
+];


### PR DESCRIPTION
This PR lets you create `blech32m` confidential addresses (witness version 1 address). 

* support `EncodingType` in `Blech32Address` class
* add some tests for blech32m addresses

@tiero please review 