### PR TITLE
remove fixed len check for witness v > 0

### DIFF
--- a/src/blech32Addr.ts
+++ b/src/blech32Addr.ts
@@ -29,7 +29,11 @@ function encodeAddress({
   ]);
   const witnessProgLength = witnessProgram.length;
 
-  if (witnessProgLength !== 53 && witnessProgLength !== 65)
+  if (
+    witnessVersion === 0 &&
+    witnessProgLength !== 53 &&
+    witnessProgLength !== 65
+  )
     throw new Error(
       "witness version 0 needs witness program length = 53 OR = 65"
     );

--- a/test/fixtures/blech32mAddress.fixture.ts
+++ b/test/fixtures/blech32mAddress.fixture.ts
@@ -6,6 +6,14 @@ export const validFixtures = [
     blindingPublicKey:
       "02bb66710acfd4346bebd772eb9462279a8fa4bd93763b5a7373bf1938c84dae53",
     prefix: "tex"
+  },
+  {
+    address:
+      "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh984q4gcw7w66d6rlf7d",
+    witness: "d415468",
+    blindingPublicKey:
+      "02bb66710acfd4346bebd772eb9462279a8fa4bd93763b5a7373bf1938c84dae53",
+    prefix: "tex"
   }
 ];
 


### PR DESCRIPTION
The check for data's len was applied if witness version != 0, causing error in confidential taproot (v1) address creation (`toConfidentialSegwit` in liquidjs-lib).

@tiero please review