### PR TITLE
[HOTFIX] Fix BLECH32m encoding const

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Elements extended [BIP173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) compatible Blech32 encoding/decoding library.
 
+This package provides two types of encoding:
+ * BLECH32 for witness version 0.
+ * BLECH32M for witness version 1-16. _Note that the blech32m encoding const on Liquid differs from the bitcoin one_ 
+
 ## Example
 
 Check out [tests](./test/blech32Address.test.ts) that also demonstrate how to serialize a pubkey and a witness program for generating a confidential address.

--- a/src/blech32.ts
+++ b/src/blech32.ts
@@ -37,7 +37,7 @@ function getEncodingConst(enc: EncodingType): Long.Long {
   if (enc === BLECH32) {
     return Long.fromNumber(1);
   } else if (enc === BLECH32M) {
-    return hexToLong("2bc830a3");
+    return hexToLong("455972a3350f7a1");
   } else {
     throw new Error("Invalid encoding type");
   }
@@ -165,7 +165,7 @@ export function decode(
   }
 
   if (!verifyChecksum(hrp, data, enc)) {
-    throw new Error(`invalid ${enc} checksum`);
+    throw new Error(`invalid ${enc} checksum "${blechString}"`);
   }
 
   return { hrp: hrp, data: Uint8Array.from(data.slice(0, data.length - 12)) };

--- a/test/fixtures/blech32.fixture.ts
+++ b/test/fixtures/blech32.fixture.ts
@@ -26,13 +26,13 @@ export const invalidBlech32 = [
 ];
 
 export const validBlech32m = [
-  "A133NZFWVCXJEF",
-  "a133nzfwvcxjef",
-  "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11vg8ylhta2dy0",
-  "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqqjhrygyn0ncn",
-  "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll8sz3j03mua7w",
-  "split1checkupstagehandshakeupstreamerranterredcaperredegneyqwr444r",
-  "?19dv34tya9u5k"
+  "A1EYL4VXQ3HRPT",
+  "a1eyl4vxq3hrpt",
+  "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11yatn6l85muud",
+  "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqg8m5pqg67zq3",
+  "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll09wxh8ajdvxv",
+  "split1checkupstagehandshakeupstreamerranterredcaperred3alwpgz2yydp",
+  "?1dcqxsrg55dv5"
 ];
 
 export const invalidBlech32m = [

--- a/test/fixtures/blech32mAddress.fixture.ts
+++ b/test/fixtures/blech32mAddress.fixture.ts
@@ -1,11 +1,27 @@
 export const validFixtures = [
   {
     address:
-      "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqzacec9ttt8re",
+      "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hq2g5wad8z6kmm",
     witness: "d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
     blindingPublicKey:
       "02bb66710acfd4346bebd772eb9462279a8fa4bd93763b5a7373bf1938c84dae53",
     prefix: "tex"
+  },
+  {
+    address:
+      "tex1pq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh984q4gcxtzdl9k2wcx0",
+    witness: "d415468",
+    blindingPublicKey:
+      "02bb66710acfd4346bebd772eb9462279a8fa4bd93763b5a7373bf1938c84dae53",
+    prefix: "tex"
+  },
+  {
+    address:
+      "el1pqt2ggkpvrffw5t5zw4mpu23f8kppcw3mr258cpy8nhcnwdmle20g9uda2jsjhgvv6nvg600v68slq6044k5z4v3cwk5252k8whkzkc0kcu6mzca78auu",
+    witness: "f1bd54a12ba18cd4d88d3decd1e1f069f5ada82ab23875a8aa2ac775ec2b61f6",
+    blindingPublicKey:
+      "02d484582c1a52ea2e8275761e2a293d821c3a3b1aa87c04879df137377fca9e82",
+    prefix: "el"
   }
 ];
 


### PR DESCRIPTION
**This PR fixes a critical error about blech32m encoding.** 

The lib was using the bech32m constant instead of the b**l**ech32m one. causing addresses' checksum to be invalid and so rejected by elements nodes.

https://github.com/ElementsProject/elements/blob/24ab49d110615f17fcb63ec21e8bb5d6c10aa9d7/src/blech32.cpp#L35-L46

```cpp
// ELEMENTS: this encoding constant is a random 60-byte number generated
//  in sage. For bech32m, Pieter did a fair bit of grinding to choose
//  an optimal constant. For blech32m we did no such grinding ... but
//  having said this, our only hard design constraint is that we need to
//  avoid 1, which has special algebraic structure that leads to extension
//  attacks.
//
//  Further, because blech32m is a longer code than bech32m, doing an
//  analogous grinding project would be intractable, even if we were
//  willing to put the time and effort in.

/* Determine the final constant to use for the specified encoding. */
```

- updated fixtures from elements
- updated blech32m constant
- add a test with segwit v1 address created with nigiri

@tiero please review